### PR TITLE
Part 1: Login

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -1,0 +1,234 @@
+{
+  env: {
+    es6: true
+  },
+
+  'parser': "babel-eslint",
+  'parserOptions': {
+    'sourceType': "module",
+  },
+  'plugins': [
+    "react"
+  ],
+
+  // https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb
+  'rules': {
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+
+    'no-unused-vars': [1, {vars: all, args: after-used}],
+
+    "object-curly-spacing": [2, "always", {
+      "objectsInObjects": false,
+      "arraysInObjects": false
+    }],
+    'semi': 2,
+    "quotes": [1, "single", "avoid-escape"],
+
+    // treat var statements as if they were block scoped
+    'block-scoped-var': 2,
+    # // require return statements to either always or never specify values
+    # 'consistent-return': 2,
+    # // specify curly brace conventions for all control statements
+    # 'curly': [2, 'multi-or-nest'],
+    // require default case in switch statements
+    'default-case': 2,
+    // encourages use of dot notation whenever possible
+    'dot-notation': [2, { 'allowKeywords': true }],
+    // enforces consistent newlines before or after dots
+    'dot-location': 0,
+    // require the use of === and !==
+    'eqeqeq': 2,
+    // make sure for-in loops have an if statement
+    'guard-for-in': 2,
+    // disallow use of arguments.caller or arguments.callee
+    'no-caller': 2,
+    # // disallow else after a return in an if
+    # 'no-else-return': 2,
+    // disallow comparisons to null without a type-checking operator
+    'no-eq-null': 0,
+    // disallow use of eval()
+    'no-eval': 2,
+    // disallow adding to native types
+    'no-extend-native': 2,
+    // disallow unnecessary function binding
+    'no-extra-bind': 2,
+    // disallow fallthrough of case statements
+    'no-fallthrough': 2,
+    // disallow the use of leading or trailing decimal points in numeric literals
+    'no-floating-decimal': 2,
+    // disallow the type conversions with shorter notations
+    'no-implicit-coercion': 0,
+    // disallow use of eval()-like methods
+    'no-implied-eval': 2,
+    // disallow usage of __iterator__ property
+    'no-iterator': 2,
+    // disallow use of labeled statements
+    'no-labels': 2,
+    // disallow unnecessary nested blocks
+    'no-lone-blocks': 2,
+    // disallow creation of functions within loops
+    'no-loop-func': 2,
+    // disallow use of multiple spaces
+    'no-multi-spaces': 2,
+    // disallow use of multiline strings
+    'no-multi-str': 2,
+    // disallow reassignments of native objects
+    'no-native-reassign': 2,
+    // disallow use of new operator when not part of the assignment or comparison
+    'no-new': 2,
+    // disallow use of new operator for Function object
+    'no-new-func': 2,
+    // disallows creating new instances of String,Number, and Boolean
+    'no-new-wrappers': 2,
+    // disallow use of (old style) octal literals
+    'no-octal': 2,
+    // disallow reassignment of function parameters
+    // disallow parameter object manipulation
+    // rule: http://eslint.org/docs/rules/no-param-reassign.html
+    'no-param-reassign': [0, { 'props': true }],
+    // disallow usage of __proto__ property
+    'no-proto': 2,
+    // disallow declaring the same variable more then once
+    'no-redeclare': 2,
+    // disallow use of assignment in return statement
+    'no-return-assign': 2,
+    // disallow use of javascript: urls.
+    'no-script-url': 2,
+    // disallow comparisons where both sides are exactly the same
+    'no-self-compare': 2,
+    // disallow use of comma operator
+    'no-sequences': 2,
+    // restrict what can be thrown as an exception
+    'no-throw-literal': 2,
+    // disallow usage of expressions in statement position
+    'no-unused-expressions': 2,
+    // disallow unnecessary .call() and .apply()
+    'no-useless-call': 0,
+    // disallow use of void operator
+    'no-void': 0,
+    // disallow usage of configurable warning terms in comments: e.g. todo
+    'no-warning-comments': [0, { 'terms': ['todo', 'fixme', 'xxx'], 'location': 'start' }],
+    // disallow use of the with statement
+    'no-with': 2,
+    // require use of the second argument for parseInt()
+    'radix': 2,
+    // requires to declare all vars on top of their containing scope
+    'vars-on-top': 2,
+    // require immediate function invocation to be wrapped in parentheses
+    // http://eslint.org/docs/rules/wrap-iife.html
+    'wrap-iife': [2, 'outside'],
+    // require or disallow Yoda conditions
+    'yoda': 2,
+
+    // STYLE:
+    // enforce spacing inside array brackets
+    'array-bracket-spacing': [2, 'never'],
+    // enforce one true brace style
+    'brace-style': [2, '1tbs', { 'allowSingleLine': true }],
+    // enforce spacing before and after comma
+    'comma-spacing': [2, { 'before': false, 'after': true }],
+    // enforce one true comma style
+    'comma-style': [2, 'last'],
+    // disallow padding inside computed properties
+    'computed-property-spacing': [2, 'never'],
+    // enforces consistent naming when capturing the current execution context
+    'consistent-this': 0,
+    // enforce newline at the end of file, with no multiple empty lines
+    'eol-last': 2,
+    // require function expressions to have a name
+    'func-names': 0,
+    // enforces use of function declarations or expressions
+    'func-style': 0,
+    // this option enforces minimum and maximum identifier lengths
+    // (variable names, property names etc.)
+    'id-length': 0,
+    # // this option sets a specific tab width for your code
+    # // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
+    # 'indent': [2, 2, { 'SwitchCase': 1, 'VariableDeclarator': 1 }],
+    // specify whether double or single quotes should be used in JSX attributes
+    // http://eslint.org/docs/rules/jsx-quotes
+    'jsx-quotes': [2, 'prefer-double'],
+    // enforces spacing between keys and values in object literal properties
+    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],
+    // enforces empty lines around comments
+    'lines-around-comment': 0,
+    // disallow mixed 'LF' and 'CRLF' as linebreaks
+    'linebreak-style': 0,
+    // specify the maximum length of a line in your program
+    // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
+    'max-len': [0, 100, 2, {
+      'ignoreUrls': true,
+      'ignoreComments': false
+    }],
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': 0,
+    // require a capital letter for constructors
+    'new-cap': [2, { 'newIsCap': true }],
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    'new-parens': 0,
+    // allow/disallow an empty newline after var statement
+    'newline-after-var': 0,
+    // disallow use of the Array constructor
+    'no-array-constructor': 0,
+    // disallow use of the continue statement
+    'no-continue': 0,
+    // disallow comments inline after code
+    'no-inline-comments': 0,
+    // disallow if as the only statement in an else block
+    'no-lonely-if': 0,
+    // disallow mixed spaces and tabs for indentation
+    'no-mixed-spaces-and-tabs': 2,
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, { 'max': 2, 'maxEOF': 1 }],
+    // disallow nested ternary expressions
+    'no-nested-ternary': 2,
+    // disallow use of the Object constructor
+    'no-new-object': 2,
+    // disallow space between function identifier and application
+    'no-spaced-func': 2,
+    // disallow the use of ternary operators
+    'no-ternary': 0,
+    // disallow trailing whitespace at the end of lines
+    'no-trailing-spaces': 2,
+    // disallow dangling underscores in identifiers
+    'no-underscore-dangle': 0,
+    // disallow the use of Boolean literals in conditional expressions
+    'no-unneeded-ternary': 0,
+    // allow just one var statement per function
+    'one-var': [2, 'never'],
+    // require assignment operator shorthand where possible or prohibit it entirely
+    'operator-assignment': 0,
+    // enforce operators to be placed before or after line breaks
+    'operator-linebreak': 0,
+    // enforce padding within blocks
+    'padded-blocks': [2, 'never'],
+    // require quotes around object literal property names
+    // http://eslint.org/docs/rules/quote-props.html
+    'quote-props': [2, 'as-needed', { 'keywords': false, 'unnecessary': false, 'numbers': false }],
+    // require identifiers to match the provided regular expression
+    'id-match': 0,
+    // enforce spacing before and after semicolons
+    'semi-spacing': [2, { 'before': false, 'after': true }],
+    // sort variables within the same declaration block
+    'sort-vars': 0,
+    // require or disallow space before blocks
+    'space-before-blocks': 2,
+    // require or disallow space before function opening parenthesis
+    // https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md
+    'space-before-function-paren': [2, { 'anonymous': 'never', 'named': 'never' }],
+    // require or disallow spaces inside parentheses
+    'space-in-parens': [2, 'never'],
+    // require spaces around operators
+    'space-infix-ops': 2,
+    // Require or disallow spaces before/after unary operators
+    'space-unary-ops': 0,
+    // require or disallow a space immediately following the // or /* in a comment
+    'spaced-comment': [0, 'always', {
+      'exceptions': ['-', '+'],
+      'markers': ['=', '!']           // space here to support sprockets directives
+    }],
+    // require regex literals to be wrapped in parentheses
+    'wrap-regex': 0
+  }
+}

--- a/app/src/components/LoggedinView.js
+++ b/app/src/components/LoggedinView.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const getUserObject = (data, user) => {
+  if (!user) {
+    return data && data.me && data.me.name;
+  }
+  return user && user.name;
+};
+
+const LoggedinView = ({ data, user }) => (
+  <div>Hello, {getUserObject(data, user)}!</div>
+);
+
+export default LoggedinView;

--- a/app/src/components/LoggedinView.js
+++ b/app/src/components/LoggedinView.js
@@ -1,14 +1,9 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
-const getUserObject = (data, user) => {
-  if (!user) {
-    return data && data.me && data.me.name;
-  }
-  return user && user.name;
-};
-
-const LoggedinView = ({ data, user }) => (
-  <div>Hello, {getUserObject(data, user)}!</div>
+const LoggedinView = ({ data }) => (
+  <Fragment>
+    Hello, {data && data.me && data.me.name}!
+  </Fragment>
 );
 
 export default LoggedinView;

--- a/app/src/components/LoginForm.js
+++ b/app/src/components/LoginForm.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import FormControl from '@material-ui/core/FormControl';
+import Button from '@material-ui/core/Button';
+import { compose, withHandlers, withState } from 'recompose';
+
+const handleLogin = ({ email, loginMutation, password }) => () => (
+  loginMutation({ email, password })
+);
+
+const onChangeEmail = ({ setEmail }) => ({ target: { value }}) => {
+  setEmail(value);
+};
+
+const onChangePassword = ({ setPassword }) => ({ target: { value }}) => {
+  setPassword(value);
+};
+
+const LoginForm = ({
+  email,
+  handleLogin,
+  password,
+  onChangeEmail,
+  onChangePassword,
+}) => (
+  <div>
+    <FormControl fullWidth>
+      <TextField
+        label="Email:"
+        onChange={onChangeEmail}
+        value={email}
+      />
+    </FormControl>
+    <FormControl fullWidth>
+      <TextField
+        label="Password:"
+        onChange={onChangePassword}
+        type="password"
+        value={password}
+      />
+    </FormControl>
+    <Button color="primary" onClick={handleLogin}>Login</Button>
+  </div>
+);
+
+const enhanced = compose(
+  withState('email', 'setEmail', ''),
+  withState('password', 'setPassword', ''),
+  withHandlers({
+    handleLogin,
+    onChangeEmail,
+    onChangePassword,
+  })
+);
+export default enhanced(LoginForm);

--- a/app/src/components/TestPage.js
+++ b/app/src/components/TestPage.js
@@ -4,6 +4,7 @@ import { compose } from 'recompose';
 import FeedData from '../containers/FeedData';
 import FeedSubscriptionData from '../containers/FeedSubscriptionData';
 import ListComments from './ListComments';
+import GetUser from '../containers/GetUser';
 import LoginContainer from '../containers/LoginContainer';
 import Notice from './Notice';
 
@@ -20,7 +21,9 @@ const enhanced = compose(withStyles(styles));
 
 export default enhanced(({ classes }) => (
   <div className={classes.page}>
-    <LoginContainer />
+    <GetUser>
+      {props => <LoginContainer {...props} />}
+    </GetUser>
     <FeedSubscriptionData>
       {props => <Notice {...props} />}
     </FeedSubscriptionData>

--- a/app/src/components/TestPage.js
+++ b/app/src/components/TestPage.js
@@ -4,6 +4,7 @@ import { compose } from 'recompose';
 import FeedData from '../containers/FeedData';
 import FeedSubscriptionData from '../containers/FeedSubscriptionData';
 import ListComments from './ListComments';
+import LoginContainer from '../containers/LoginContainer';
 import Notice from './Notice';
 
 const styles = theme => ({
@@ -19,6 +20,7 @@ const enhanced = compose(withStyles(styles));
 
 export default enhanced(({ classes }) => (
   <div className={classes.page}>
+    <LoginContainer />
     <FeedSubscriptionData>
       {props => <Notice {...props} />}
     </FeedSubscriptionData>

--- a/app/src/containers/CheckAuth.js
+++ b/app/src/containers/CheckAuth.js
@@ -9,7 +9,7 @@ const checkAuth = isAuthenticated => branch(
 );
 
 const query = gql`
-  query {
+  query me {
     me {
       name
     }

--- a/app/src/containers/CheckAuth.js
+++ b/app/src/containers/CheckAuth.js
@@ -1,0 +1,24 @@
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { compose, branch, renderComponent, renderNothing } from 'recompose';
+
+const checkAuth = isAuthenticated => branch(
+  isAuthenticated,
+  renderComponent(props => props.children),
+  renderNothing,
+);
+
+const query = gql`
+  query {
+    me {
+      name
+    }
+  }
+`;
+
+const enhanced = compose(
+  graphql(query),
+  checkAuth(({ data, not }) => (data && data.me && !not) || (!(data && data.me) && not))
+);
+
+export default enhanced();

--- a/app/src/containers/GetUser.js
+++ b/app/src/containers/GetUser.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { compose, withProps, toRenderProps } from 'recompose';
 
 const query = gql`
-  query {
+  query me {
     me {
       name
     }
@@ -12,9 +12,7 @@ const query = gql`
 
 const enhanced = compose(
   graphql(query),
-  withProps(({ data: { me }}) => ({
-    user: me,
-  }))
+  withProps(({ data: { me }}) => me)
 );
 
 export default toRenderProps(enhanced);

--- a/app/src/containers/GetUser.js
+++ b/app/src/containers/GetUser.js
@@ -1,0 +1,20 @@
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { compose, withProps, toRenderProps } from 'recompose';
+
+const query = gql`
+  query {
+    me {
+      name
+    }
+  }
+`;
+
+const enhanced = compose(
+  graphql(query),
+  withProps(({ data: { me }}) => ({
+    user: me,
+  }))
+);
+
+export default toRenderProps(enhanced);

--- a/app/src/containers/LoginContainer.js
+++ b/app/src/containers/LoginContainer.js
@@ -1,0 +1,52 @@
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { branch, compose, renderComponent, withHandlers, withState } from 'recompose';
+import LoginForm from '../components/LoginForm';
+import LoggedinView from '../components/LoggedinView';
+
+const checkUserState = noUserData => branch(
+  noUserData,
+  renderComponent(LoginForm),
+  renderComponent(LoggedinView),
+);
+
+const loginMutationHandler = ({ mutate, setUser }) => ({ email, password }) => (
+  mutate({
+    variables: { email, password }
+  })
+  .then(({ data: { login: { user }}}) => {
+    if (user) {
+      setUser(user);
+    }
+  })
+);
+
+const loginMutation = gql`
+  mutation($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      user {
+        name
+      }
+    }
+  }
+`;
+
+const query = gql`
+  query {
+    me {
+      name
+    }
+  }
+`;
+
+const enhanced = compose(
+  graphql(query),
+  graphql(loginMutation),
+  withState('user', 'setUser', null),
+  withHandlers({
+    loginMutation: loginMutationHandler,
+  }),
+  checkUserState(props => !props.data.me && !props.user),
+);
+
+export default enhanced();

--- a/app/src/containers/LoginContainer.js
+++ b/app/src/containers/LoginContainer.js
@@ -4,7 +4,7 @@ import { branch, compose, renderComponent, withHandlers, withState } from 'recom
 import LoginForm from '../components/LoginForm';
 import LoggedinView from '../components/LoggedinView';
 
-const checkUserState = noUserData => branch(
+const checkAuth = noUserData => branch(
   noUserData,
   renderComponent(LoginForm),
   renderComponent(LoggedinView),
@@ -31,22 +31,13 @@ const loginMutation = gql`
   }
 `;
 
-const query = gql`
-  query {
-    me {
-      name
-    }
-  }
-`;
-
 const enhanced = compose(
-  graphql(query),
   graphql(loginMutation),
   withState('user', 'setUser', null),
   withHandlers({
     loginMutation: loginMutationHandler,
   }),
-  checkUserState(props => !props.data.me && !props.user),
+  checkAuth(props => !(props.data && props.data.me) && !props.user),
 );
 
 export default enhanced();

--- a/app/src/providers/DataProvider.js
+++ b/app/src/providers/DataProvider.js
@@ -18,7 +18,8 @@ const wsLink = new WebSocketLink({
   }
 });
 const httpLink = new HttpLink({
-  uri: HTTP_URL
+  uri: HTTP_URL,
+  credentials: 'include',
 });
 
 const link = split(

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,8 @@
     "bcryptjs": "2.4.3",
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
+    "cookie-parser": "^1.4.3",
+    "cors": "^2.8.5",
     "graphql-yoga": "1.16.2",
     "jsonwebtoken": "8.3.0",
     "mocha": "^5.2.0",

--- a/server/src/generated/prisma.graphql
+++ b/server/src/generated/prisma.graphql
@@ -1,5 +1,5 @@
-# source: https://us1.prisma.sh/public-graveldevourer-868/graphql-boilerplate/dev
-# timestamp: Tue Oct 16 2018 14:33:42 GMT-0600 (Mountain Daylight Time)
+# source: https://us1.prisma.sh/public-carnationcub-448/makana-rpt-ui/dev
+# timestamp: Wed Nov 21 2018 00:22:13 GMT+0000 (Coordinated Universal Time)
 
 type AggregateComment {
   count: Int!
@@ -109,6 +109,145 @@ type CommentPreviousValues {
   message: String!
 }
 
+input CommentScalarWhereInput {
+  """Logical AND on all given filters."""
+  AND: [CommentScalarWhereInput!]
+
+  """Logical OR on all given filters."""
+  OR: [CommentScalarWhereInput!]
+
+  """Logical NOT on all given filters combined by AND."""
+  NOT: [CommentScalarWhereInput!]
+  id: ID
+
+  """All values that are not equal to given value."""
+  id_not: ID
+
+  """All values that are contained in given list."""
+  id_in: [ID!]
+
+  """All values that are not contained in given list."""
+  id_not_in: [ID!]
+
+  """All values less than the given value."""
+  id_lt: ID
+
+  """All values less than or equal the given value."""
+  id_lte: ID
+
+  """All values greater than the given value."""
+  id_gt: ID
+
+  """All values greater than or equal the given value."""
+  id_gte: ID
+
+  """All values containing the given string."""
+  id_contains: ID
+
+  """All values not containing the given string."""
+  id_not_contains: ID
+
+  """All values starting with the given string."""
+  id_starts_with: ID
+
+  """All values not starting with the given string."""
+  id_not_starts_with: ID
+
+  """All values ending with the given string."""
+  id_ends_with: ID
+
+  """All values not ending with the given string."""
+  id_not_ends_with: ID
+  createdAt: DateTime
+
+  """All values that are not equal to given value."""
+  createdAt_not: DateTime
+
+  """All values that are contained in given list."""
+  createdAt_in: [DateTime!]
+
+  """All values that are not contained in given list."""
+  createdAt_not_in: [DateTime!]
+
+  """All values less than the given value."""
+  createdAt_lt: DateTime
+
+  """All values less than or equal the given value."""
+  createdAt_lte: DateTime
+
+  """All values greater than the given value."""
+  createdAt_gt: DateTime
+
+  """All values greater than or equal the given value."""
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+
+  """All values that are not equal to given value."""
+  updatedAt_not: DateTime
+
+  """All values that are contained in given list."""
+  updatedAt_in: [DateTime!]
+
+  """All values that are not contained in given list."""
+  updatedAt_not_in: [DateTime!]
+
+  """All values less than the given value."""
+  updatedAt_lt: DateTime
+
+  """All values less than or equal the given value."""
+  updatedAt_lte: DateTime
+
+  """All values greater than the given value."""
+  updatedAt_gt: DateTime
+
+  """All values greater than or equal the given value."""
+  updatedAt_gte: DateTime
+  isPublic: Boolean
+
+  """All values that are not equal to given value."""
+  isPublic_not: Boolean
+  message: String
+
+  """All values that are not equal to given value."""
+  message_not: String
+
+  """All values that are contained in given list."""
+  message_in: [String!]
+
+  """All values that are not contained in given list."""
+  message_not_in: [String!]
+
+  """All values less than the given value."""
+  message_lt: String
+
+  """All values less than or equal the given value."""
+  message_lte: String
+
+  """All values greater than the given value."""
+  message_gt: String
+
+  """All values greater than or equal the given value."""
+  message_gte: String
+
+  """All values containing the given string."""
+  message_contains: String
+
+  """All values not containing the given string."""
+  message_not_contains: String
+
+  """All values starting with the given string."""
+  message_starts_with: String
+
+  """All values not starting with the given string."""
+  message_not_starts_with: String
+
+  """All values ending with the given string."""
+  message_ends_with: String
+
+  """All values not ending with the given string."""
+  message_not_ends_with: String
+}
+
 type CommentSubscriptionPayload {
   mutation: MutationType!
   node: Comment
@@ -156,12 +295,24 @@ input CommentUpdateInput {
   parent: CommentUpdateOneWithoutChildrenInput
 }
 
+input CommentUpdateManyDataInput {
+  isPublic: Boolean
+  message: String
+}
+
+input CommentUpdateManyMutationInput {
+  isPublic: Boolean
+  message: String
+}
+
 input CommentUpdateManyWithoutAuthorInput {
   create: [CommentCreateWithoutAuthorInput!]
   connect: [CommentWhereUniqueInput!]
   disconnect: [CommentWhereUniqueInput!]
   delete: [CommentWhereUniqueInput!]
   update: [CommentUpdateWithWhereUniqueWithoutAuthorInput!]
+  updateMany: [CommentUpdateManyWithWhereNestedInput!]
+  deleteMany: [CommentScalarWhereInput!]
   upsert: [CommentUpsertWithWhereUniqueWithoutAuthorInput!]
 }
 
@@ -171,7 +322,14 @@ input CommentUpdateManyWithoutParentInput {
   disconnect: [CommentWhereUniqueInput!]
   delete: [CommentWhereUniqueInput!]
   update: [CommentUpdateWithWhereUniqueWithoutParentInput!]
+  updateMany: [CommentUpdateManyWithWhereNestedInput!]
+  deleteMany: [CommentScalarWhereInput!]
   upsert: [CommentUpsertWithWhereUniqueWithoutParentInput!]
+}
+
+input CommentUpdateManyWithWhereNestedInput {
+  where: CommentScalarWhereInput!
+  data: CommentUpdateManyDataInput!
 }
 
 input CommentUpdateOneWithoutChildrenInput {
@@ -396,8 +554,8 @@ type Mutation {
   deleteUser(where: UserWhereUniqueInput!): User
   upsertComment(where: CommentWhereUniqueInput!, create: CommentCreateInput!, update: CommentUpdateInput!): Comment!
   upsertUser(where: UserWhereUniqueInput!, create: UserCreateInput!, update: UserUpdateInput!): User!
-  updateManyComments(data: CommentUpdateInput!, where: CommentWhereInput): BatchPayload!
-  updateManyUsers(data: UserUpdateInput!, where: UserWhereInput): BatchPayload!
+  updateManyComments(data: CommentUpdateManyMutationInput!, where: CommentWhereInput): BatchPayload!
+  updateManyUsers(data: UserUpdateManyMutationInput!, where: UserWhereInput): BatchPayload!
   deleteManyComments(where: CommentWhereInput): BatchPayload!
   deleteManyUsers(where: UserWhereInput): BatchPayload!
 }
@@ -560,6 +718,12 @@ input UserUpdateInput {
   password: String
   name: String
   comments: CommentUpdateManyWithoutAuthorInput
+}
+
+input UserUpdateManyMutationInput {
+  email: String
+  password: String
+  name: String
 }
 
 input UserUpdateOneRequiredWithoutCommentsInput {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -20,6 +20,6 @@ server.express.use(cookieParser());
 server.express.use(sendCookieTokenMiddleware);
 
 server.start(
-  { cors: { origin: 'http://localhost:3000', credentials: true }},
+  { cors: { origin: /^https?:\/\/(localhost:)(.*)/, credentials: true }},
   () => console.log('Server is running on http://localhost:4000')
 );

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,7 +2,6 @@ const { GraphQLServer } = require('graphql-yoga');
 const { Prisma } = require('prisma-binding');
 const cookieParser = require('cookie-parser');
 const resolvers = require('./resolvers');
-const { sendCookieTokenMiddleware } = require('./utils');
 
 const db = new Prisma({
   typeDefs: 'src/generated/prisma.graphql',
@@ -17,7 +16,6 @@ const server = new GraphQLServer({
 });
 
 server.express.use(cookieParser());
-server.express.use(sendCookieTokenMiddleware);
 
 server.start(
   { cors: { origin: /^https?:\/\/(localhost:)(.*)/, credentials: true }},

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,6 +1,8 @@
 const { GraphQLServer } = require('graphql-yoga');
 const { Prisma } = require('prisma-binding');
+const cookieParser = require('cookie-parser');
 const resolvers = require('./resolvers');
+const { sendCookieTokenMiddleware } = require('./utils');
 
 const db = new Prisma({
   typeDefs: 'src/generated/prisma.graphql',
@@ -14,4 +16,10 @@ const server = new GraphQLServer({
   context: req => ({ ...req, db })
 });
 
-server.start(() => console.log('Server is running on http://localhost:4000'));
+server.express.use(cookieParser());
+server.express.use(sendCookieTokenMiddleware);
+
+server.start(
+  { cors: { origin: 'http://localhost:3000', credentials: true }},
+  () => console.log('Server is running on http://localhost:4000')
+);

--- a/server/src/resolvers/Mutation/auth.js
+++ b/server/src/resolvers/Mutation/auth.js
@@ -28,13 +28,12 @@ const auth = {
       throw new Error('Invalid password');
     }
 
-    return {
-      token: jwt.sign(
-        { userId: user.id, name: user.name },
-        process.env.APP_SECRET
-      ),
-      user
-    };
+    const token = jwt.sign({ userId: user.id, name: user.name }, process.env.APP_SECRET);
+    const DAYS_7 = 1000 * 60 * 60 * 24 * 7;
+    const cookieOptions = { httpOnly: true, maxAge: DAYS_7 };
+    ctx.response.cookie('token', token, cookieOptions);
+
+    return { user, token };
   }
 };
 

--- a/server/src/resolvers/Query.js
+++ b/server/src/resolvers/Query.js
@@ -1,4 +1,4 @@
-const { getUserId, getUserIdOptional, AuthError } = require('../utils');
+const { getUserIdOptional, AuthError } = require('../utils');
 
 const Query = {
   feed(parent, args, ctx, info) {
@@ -34,7 +34,7 @@ const Query = {
   },
 
   me(parent, args, ctx, info) {
-    const id = getUserId(ctx);
+    const id = getUserIdOptional(ctx);
     return ctx.db.query.user({ where: { id } }, info);
   }
 };

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -12,6 +12,9 @@ function getUserId(ctx, optional = false) {
   }
 
   if (!optional) {
+    // refetchQueries will not recover from error!
+    // use getUserIdOptional instead when possible
+    // https://github.com/apollographql/react-apollo/issues/2070
     throw new AuthError();
   }
 

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -31,21 +31,8 @@ class AuthError extends Error {
   }
 }
 
-const sendCookieTokenMiddleware = async (req, res, next) => {
-  const token = req.cookies.token;
-  if (!token) {
-    return next();
-  }
-  const { user } = jwt.verify(token, process.env.APP_SECRET);
-  if (user) {
-    req.user = user;
-  }
-  return next();
-};
-
 module.exports = {
   getUserId,
   getUserIdOptional,
   AuthError,
-  sendCookieTokenMiddleware,
 };

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1244,6 +1244,14 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
+cookie-parser@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"
+  integrity sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -1287,6 +1295,14 @@ cors@^2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
   integrity sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
   dependencies:
     object-assign "^4"
     vary "^1"


### PR DESCRIPTION
- server is setting cookie to store auth token (still need to add logic to refresh expired tokens) 
- using `refetchQuery` to get fresh data after a user logs in, however there is a bug in the library which brakes `refetchQuery` if an error was previously thrown for a response: [see here](https://github.com/jneiku/makana-rpt-ui/pull/1/files#diff-0c0f30b4dc8b5e15aab676fb473b74a4R15) I worked around the issue by changing `query me` to use `getUserIdOptional` which doesn't thrown an error
- I learned that it's important to name the queries, otherwise `refetchQuery` magic doesn't work. Queries should be consolidated in a single file as suggested by Apollo code pattern docs. 

### login form and public feed
![screenshot 2018-11-26 at 11 11 17 am](https://user-images.githubusercontent.com/226705/49036242-0fe18500-f16c-11e8-88c0-bb5e7b2aff20.png)

### authenticated view
![screenshot 2018-11-26 at 11 10 54 am](https://user-images.githubusercontent.com/226705/49036245-107a1b80-f16c-11e8-8ff6-104eefb3e475.png)
