### PR TITLE
Part 5: Authenticated subscriptions

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -1,0 +1,234 @@
+{
+  env: {
+    es6: true
+  },
+
+  'parser': "babel-eslint",
+  'parserOptions': {
+    'sourceType': "module",
+  },
+  'plugins': [
+    "react"
+  ],
+
+  // https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb
+  'rules': {
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+
+    'no-unused-vars': [1, {vars: all, args: after-used}],
+
+    "object-curly-spacing": [2, "always", {
+      "objectsInObjects": false,
+      "arraysInObjects": false
+    }],
+    'semi': 2,
+    "quotes": [1, "single", "avoid-escape"],
+
+    // treat var statements as if they were block scoped
+    'block-scoped-var': 2,
+    # // require return statements to either always or never specify values
+    # 'consistent-return': 2,
+    # // specify curly brace conventions for all control statements
+    # 'curly': [2, 'multi-or-nest'],
+    // require default case in switch statements
+    'default-case': 2,
+    // encourages use of dot notation whenever possible
+    'dot-notation': [2, { 'allowKeywords': true }],
+    // enforces consistent newlines before or after dots
+    'dot-location': 0,
+    // require the use of === and !==
+    'eqeqeq': 2,
+    // make sure for-in loops have an if statement
+    'guard-for-in': 2,
+    // disallow use of arguments.caller or arguments.callee
+    'no-caller': 2,
+    # // disallow else after a return in an if
+    # 'no-else-return': 2,
+    // disallow comparisons to null without a type-checking operator
+    'no-eq-null': 0,
+    // disallow use of eval()
+    'no-eval': 2,
+    // disallow adding to native types
+    'no-extend-native': 2,
+    // disallow unnecessary function binding
+    'no-extra-bind': 2,
+    // disallow fallthrough of case statements
+    'no-fallthrough': 2,
+    // disallow the use of leading or trailing decimal points in numeric literals
+    'no-floating-decimal': 2,
+    // disallow the type conversions with shorter notations
+    'no-implicit-coercion': 0,
+    // disallow use of eval()-like methods
+    'no-implied-eval': 2,
+    // disallow usage of __iterator__ property
+    'no-iterator': 2,
+    // disallow use of labeled statements
+    'no-labels': 2,
+    // disallow unnecessary nested blocks
+    'no-lone-blocks': 2,
+    // disallow creation of functions within loops
+    'no-loop-func': 2,
+    // disallow use of multiple spaces
+    'no-multi-spaces': 2,
+    // disallow use of multiline strings
+    'no-multi-str': 2,
+    // disallow reassignments of native objects
+    'no-native-reassign': 2,
+    // disallow use of new operator when not part of the assignment or comparison
+    'no-new': 2,
+    // disallow use of new operator for Function object
+    'no-new-func': 2,
+    // disallows creating new instances of String,Number, and Boolean
+    'no-new-wrappers': 2,
+    // disallow use of (old style) octal literals
+    'no-octal': 2,
+    // disallow reassignment of function parameters
+    // disallow parameter object manipulation
+    // rule: http://eslint.org/docs/rules/no-param-reassign.html
+    'no-param-reassign': [0, { 'props': true }],
+    // disallow usage of __proto__ property
+    'no-proto': 2,
+    // disallow declaring the same variable more then once
+    'no-redeclare': 2,
+    // disallow use of assignment in return statement
+    'no-return-assign': 2,
+    // disallow use of javascript: urls.
+    'no-script-url': 2,
+    // disallow comparisons where both sides are exactly the same
+    'no-self-compare': 2,
+    // disallow use of comma operator
+    'no-sequences': 2,
+    // restrict what can be thrown as an exception
+    'no-throw-literal': 2,
+    // disallow usage of expressions in statement position
+    'no-unused-expressions': 2,
+    // disallow unnecessary .call() and .apply()
+    'no-useless-call': 0,
+    // disallow use of void operator
+    'no-void': 0,
+    // disallow usage of configurable warning terms in comments: e.g. todo
+    'no-warning-comments': [0, { 'terms': ['todo', 'fixme', 'xxx'], 'location': 'start' }],
+    // disallow use of the with statement
+    'no-with': 2,
+    // require use of the second argument for parseInt()
+    'radix': 2,
+    // requires to declare all vars on top of their containing scope
+    'vars-on-top': 2,
+    // require immediate function invocation to be wrapped in parentheses
+    // http://eslint.org/docs/rules/wrap-iife.html
+    'wrap-iife': [2, 'outside'],
+    // require or disallow Yoda conditions
+    'yoda': 2,
+
+    // STYLE:
+    // enforce spacing inside array brackets
+    'array-bracket-spacing': [2, 'never'],
+    // enforce one true brace style
+    'brace-style': [2, '1tbs', { 'allowSingleLine': true }],
+    // enforce spacing before and after comma
+    'comma-spacing': [2, { 'before': false, 'after': true }],
+    // enforce one true comma style
+    'comma-style': [2, 'last'],
+    // disallow padding inside computed properties
+    'computed-property-spacing': [2, 'never'],
+    // enforces consistent naming when capturing the current execution context
+    'consistent-this': 0,
+    // enforce newline at the end of file, with no multiple empty lines
+    'eol-last': 2,
+    // require function expressions to have a name
+    'func-names': 0,
+    // enforces use of function declarations or expressions
+    'func-style': 0,
+    // this option enforces minimum and maximum identifier lengths
+    // (variable names, property names etc.)
+    'id-length': 0,
+    # // this option sets a specific tab width for your code
+    # // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
+    # 'indent': [2, 2, { 'SwitchCase': 1, 'VariableDeclarator': 1 }],
+    // specify whether double or single quotes should be used in JSX attributes
+    // http://eslint.org/docs/rules/jsx-quotes
+    'jsx-quotes': [2, 'prefer-double'],
+    // enforces spacing between keys and values in object literal properties
+    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],
+    // enforces empty lines around comments
+    'lines-around-comment': 0,
+    // disallow mixed 'LF' and 'CRLF' as linebreaks
+    'linebreak-style': 0,
+    // specify the maximum length of a line in your program
+    // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
+    'max-len': [0, 100, 2, {
+      'ignoreUrls': true,
+      'ignoreComments': false
+    }],
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': 0,
+    // require a capital letter for constructors
+    'new-cap': [2, { 'newIsCap': true }],
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    'new-parens': 0,
+    // allow/disallow an empty newline after var statement
+    'newline-after-var': 0,
+    // disallow use of the Array constructor
+    'no-array-constructor': 0,
+    // disallow use of the continue statement
+    'no-continue': 0,
+    // disallow comments inline after code
+    'no-inline-comments': 0,
+    // disallow if as the only statement in an else block
+    'no-lonely-if': 0,
+    // disallow mixed spaces and tabs for indentation
+    'no-mixed-spaces-and-tabs': 2,
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, { 'max': 2, 'maxEOF': 1 }],
+    // disallow nested ternary expressions
+    'no-nested-ternary': 2,
+    // disallow use of the Object constructor
+    'no-new-object': 2,
+    // disallow space between function identifier and application
+    'no-spaced-func': 2,
+    // disallow the use of ternary operators
+    'no-ternary': 0,
+    // disallow trailing whitespace at the end of lines
+    'no-trailing-spaces': 2,
+    // disallow dangling underscores in identifiers
+    'no-underscore-dangle': 0,
+    // disallow the use of Boolean literals in conditional expressions
+    'no-unneeded-ternary': 0,
+    // allow just one var statement per function
+    'one-var': [2, 'never'],
+    // require assignment operator shorthand where possible or prohibit it entirely
+    'operator-assignment': 0,
+    // enforce operators to be placed before or after line breaks
+    'operator-linebreak': 0,
+    // enforce padding within blocks
+    'padded-blocks': [2, 'never'],
+    // require quotes around object literal property names
+    // http://eslint.org/docs/rules/quote-props.html
+    'quote-props': [2, 'as-needed', { 'keywords': false, 'unnecessary': false, 'numbers': false }],
+    // require identifiers to match the provided regular expression
+    'id-match': 0,
+    // enforce spacing before and after semicolons
+    'semi-spacing': [2, { 'before': false, 'after': true }],
+    // sort variables within the same declaration block
+    'sort-vars': 0,
+    // require or disallow space before blocks
+    'space-before-blocks': 2,
+    // require or disallow space before function opening parenthesis
+    // https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md
+    'space-before-function-paren': [2, { 'anonymous': 'never', 'named': 'never' }],
+    // require or disallow spaces inside parentheses
+    'space-in-parens': [2, 'never'],
+    // require spaces around operators
+    'space-infix-ops': 2,
+    // Require or disallow spaces before/after unary operators
+    'space-unary-ops': 0,
+    // require or disallow a space immediately following the // or /* in a comment
+    'spaced-comment': [0, 'always', {
+      'exceptions': ['-', '+'],
+      'markers': ['=', '!']           // space here to support sprockets directives
+    }],
+    // require regex literals to be wrapped in parentheses
+    'wrap-regex': 0
+  }
+}

--- a/app/src/components/CommentForm.js
+++ b/app/src/components/CommentForm.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
 import { compose, withHandlers, withState } from 'recompose';
 import FormControl from './FormControl';
 import errorForField from '../utils/errorForField';
@@ -17,17 +19,17 @@ const styles = theme => ({
   form: {
     maxWidth: 400,
     width: '80%',
-    marginTop: theme.spacing.unit * 8,
+    marginTop: theme.spacing.unit * 2,
     marginBottom: theme.spacing.unit * 2,
   }
 });
 
-const handleSubmit = ({ commentMutation, message, setErrors, setMessage }) => async event => {
+const handleSubmit = ({ commentMutation, message, isPublic, setErrors, setMessage }) => async event => {
   event.preventDefault();
   const errors = validateMessage({ message });
   setErrors(errors);
   if (errors) { return; }
-  commentMutation({ message })
+  commentMutation({ message, isPublic })
     .then(() => {
       setMessage('');
     });
@@ -46,11 +48,17 @@ const onChangeMessage = ({ errors, setErrors, setMessage }) => ({ target: { valu
   setMessage(value);
 };
 
+const onChangeIsPublic = ({ setIsPublic }) => (event, checked) => {
+  setIsPublic(checked);
+};
+
 const CommentForm = ({
   classes,
   errors,
   handleSubmit,
+  isPublic,
   message,
+  onChangeIsPublic,
   onChangeMessage,
   onKeyPress,
 }) => (
@@ -66,6 +74,17 @@ const CommentForm = ({
         onKeyPress,
       }}
     />
+    <FormControlLabel
+      control={
+        <Switch
+          checked={isPublic}
+          value={isPublic}
+          onChange={onChangeIsPublic}
+          color="primary"
+        />
+      }
+      label={isPublic ? 'Share with everyone?' : 'Only registered users'}
+    />
     <Button
       className={classes.button}
       color="primary"
@@ -79,6 +98,7 @@ const CommentForm = ({
 
 const enhanced = compose(
   withState('message', 'setMessage', ''),
+  withState('isPublic', 'setIsPublic', true),
   withState('errors', 'setErrors', null),
   withHandlers({
     handleSubmit,
@@ -86,6 +106,7 @@ const enhanced = compose(
   withHandlers({
     onKeyPress,
     onChangeMessage,
+    onChangeIsPublic,
   }),
   withStyles(styles)
 );

--- a/app/src/components/LoggedinView.js
+++ b/app/src/components/LoggedinView.js
@@ -26,7 +26,6 @@ const LoggedinView = ({ classes, data, logoutMutation }) => (
       <Typography className={classes.message} variant="h6">
         Hello, {data && data.me && data.me.name}!
       </Typography>
-      <p></p>
       <Button className={classes.button} variant="outlined" onClick={logoutMutation}>
         Logout
       </Button>

--- a/app/src/components/TestPage.js
+++ b/app/src/components/TestPage.js
@@ -32,6 +32,10 @@ export default enhanced(({ classes }) => (
     <FeedSubscriptionData>
       {props => <Notice {...props} />}
     </FeedSubscriptionData>
-    <FeedData>{props => <ListComments {...props} />}</FeedData>
+    <GetUser>
+      {({ data }) => (
+        <FeedData user={data && data.me}>{props => <ListComments {...props} />}</FeedData>
+      )}
+    </GetUser>
   </div>
 ));

--- a/app/src/containers/CommentFormContainer.js
+++ b/app/src/containers/CommentFormContainer.js
@@ -3,17 +3,17 @@ import gql from 'graphql-tag';
 import { compose, withHandlers } from 'recompose';
 import CommentForm from '../components/CommentForm';
 
-const commentMutationHandler = ({ mutate }) => ({ message }) => (
+const commentMutationHandler = ({ mutate }) => ({ message, isPublic }) => (
   mutate({
-    variables: { message }
+    variables: { message, isPublic }
   })
 );
 
 const commentMutation = gql`
-  mutation($message: String!) {
+  mutation($message: String!, $isPublic: Boolean!) {
     createComment(
       message: $message
-      isPublic: true
+      isPublic: $isPublic
     ) {
       message
     }

--- a/app/src/validators/validateLogin.js
+++ b/app/src/validators/validateLogin.js
@@ -2,7 +2,7 @@ import isEmail from 'validator/lib/isEmail';
 import isEmpty from 'validator/lib/isEmpty';
 
 const validateLogin = ({ email, password }) => {
-  if (isEmpty(email)) {
+  if (isEmpty(email, { ignore_whitespace: true })) {
     return [{ message: 'Email cannot be blank', field: 'email' }];
   }
   if (!isEmail(email)) {

--- a/app/src/validators/validateMessage.js
+++ b/app/src/validators/validateMessage.js
@@ -1,7 +1,7 @@
 import isEmpty from 'validator/lib/isEmpty';
 
 const validateMessage = ({ message }) => {
-  if (isEmpty(message)) {
+  if (isEmpty(message, { ignore_whitespace: true })) {
     return [{ message: 'Message cannot be blank', field: 'message' }];
   }
   return null;

--- a/server/src/resolvers/Subscription.js
+++ b/server/src/resolvers/Subscription.js
@@ -1,15 +1,15 @@
 const Subscription = {
   feedSubscription: {
-    subscribe: (parent, args, ctx, info) => {
-      // TODO: handle authenticated subscriptions
-      return ctx.db.subscription.comment(
-        {
-          where: {
-            node: {
-              isPublic: true
-            }
+    subscribe: (parent, { includePrivate }, ctx, info) => {
+      const queryPublic = !includePrivate ? {
+        where: {
+          node: {
+            isPublic: true
           }
-        },
+        }
+      } : {};
+      return ctx.db.subscription.comment(
+        queryPublic,
         info
       );
     }

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -20,7 +20,7 @@ type Mutation {
 }
 
 type Subscription {
-  feedSubscription: CommentSubscriptionPayload
+  feedSubscription(includePrivate: Boolean): CommentSubscriptionPayload
 }
 
 type AuthPayload {


### PR DESCRIPTION
- add private comment comment switch
- `subscribeToMore` takes a flag to include private comments as temporary solution. this type of request could be faked which is a security concern, would not ship this. WebSocket server needs to be configured so that token cookie could be read in the resolver and user verified before returning private comments. I see that cookie is sent to the server, but it does seem to be getting parsed and is not available in the subscription resolver. 

### Private/public comment switch
![screenshot 2018-11-26 at 11 30 31 am](https://user-images.githubusercontent.com/226705/49037293-b595f380-f16e-11e8-8148-ad208d5c75b8.png)
![screenshot 2018-11-26 at 11 29 46 am](https://user-images.githubusercontent.com/226705/49037261-9eef9c80-f16e-11e8-8cd6-fdb1420a18ee.png)

